### PR TITLE
Add GTK_THEME env variable for libadvaita apps theming

### DIFF
--- a/Configs/.config/hyde/themes/Catppuccin Mocha/hypr.theme
+++ b/Configs/.config/hyde/themes/Catppuccin Mocha/hypr.theme
@@ -3,6 +3,8 @@ exec = gsettings set org.gnome.desktop.interface icon-theme 'Tela-circle-dracula
 exec = gsettings set org.gnome.desktop.interface gtk-theme 'Catppuccin-Mocha'
 exec = gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
 
+env = GTK_THEME,Catppuccin-Mocha
+
 general {
     gaps_in = 3
     gaps_out = 8


### PR DESCRIPTION
Apps created using libadvaita do not use GTK theme till the `GTK_THEME` is not set.

Examples of such apps can be `gedit`, `qualculate` or file open dialog called by `Ctrl+O` in chrome, vscode and I assume a lot more apps.

This behaviour is mentioned in [Arch Wiki](https://wiki.archlinux.org/title/GTK#GTK_3_and_GTK4)

> Note: For libadwaita-based GTK 4 applications, the chosen GTK theme needs [special support](https://github.com/jnsh/arc-theme/issues/61#issuecomment-922380704) and you are required to force a GTK theme with the GTK_THEME [environment variable](https://wiki.archlinux.org/title/Environment_variable)

I have added hypr env variable to this theme, and it works for me. If this PR will be approved, I'll create same PRs for other themes.

