### PR TITLE
Active and Inactive tabs in kitty had the SAME forground and background 

### DIFF
--- a/Configs/.config/hyde/themes/Graphite Mono/kitty.theme
+++ b/Configs/.config/hyde/themes/Graphite Mono/kitty.theme
@@ -23,11 +23,11 @@ wayland_titlebar_color system
 macos_titlebar_color system
 
 # Tab bar colors
-active_tab_foreground   #D9D9D9
-active_tab_background   #262626
+active_tab_foreground   #262626  
+active_tab_background   #D9D9D9
 inactive_tab_foreground #D9D9D9
 inactive_tab_background #262626
-tab_bar_background      #D9D9D9
+tab_bar_background      #262626
 
 # Colors for marks (marked text in the terminal)
 mark1_foreground #262626


### PR DESCRIPTION
Modifed this so that Active tab has a color scheme different from inactive and in accordance with the Graphite Mono Theme; Also changed the tab-bar background color similarly

## Before the changes 
![before-changes](https://github.com/prasanthrangan/hyde-themes/assets/120457695/df84ae7e-a12b-42c5-84ea-e25ffe25a9ed)


## After changes are applied
![after-changes](https://github.com/prasanthrangan/hyde-themes/assets/120457695/d805dfaa-6204-4b12-bcc6-17bd0c05313c)
